### PR TITLE
chore(ci): update bashly, cue, ruby / debian

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-bashly 1.2.9
+bashly 1.2.12
 bats 1.11.1
-cue 0.11.0
+cue 0.12.1
 shellcheck 0.10.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian:12-slim AS base
+FROM docker.io/library/debian:trixie-slim AS base
 SHELL [ "/bin/bash", "-Eeuo", "pipefail", "-c" ]
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -34,10 +34,11 @@ SHELL [ "/bin/bash", "-Eeuo", "pipefail", "-c" ]
 # don't care about "source" warning in shellcheck
 # hadolint ignore=SC1091
 RUN \
+git config --global advice.detachedHead false && \
 curl -SsfL https://philcrockett.com/yolo/v1.sh | bash -s -- asdf && \
 asdf plugin add bashly https://github.com/pcrockett/asdf-bashly.git && \
 asdf plugin add bats https://github.com/pcrockett/asdf-bats.git && \
-asdf plugin add cue && \
+asdf plugin add cue https://github.com/asdf-community/asdf-cue.git && \
 asdf plugin add shellcheck https://github.com/pcrockett/asdf-shellcheck.git
 
 FROM base AS devenv


### PR DESCRIPTION
debian 12 (bookworm) ships end-of-life ruby 3.1.

the latest version of bashly no longer supports ruby 3.1.

however debian 13 (trixie) ships with ruby 3.3, and trixie is expected
to become stable within the next few weeks / months. so i think it's
safe to upgrade CI to use trixie.
