### PR TITLE
fix: lint error introduced by upstream change

### DIFF
--- a/src/bashly.cue
+++ b/src/bashly.cue
@@ -91,7 +91,7 @@ commands: [
 			{
 				long:  "--edit"
 				short: "-e"
-				help:  "Open config in \\$EDITOR"
+				help:  #"Open config in \$EDITOR"#
 			},
 			{
 				long:  "--no-pager"


### PR DESCRIPTION
For some reason `\\` in bashly.cue was no longer causing a literal `\` in the bashly-generated usage message. Seems like a change in cue, not sure.

In any case, I changed this part of the cue file to use a [raw string](https://cuelang.org/docs/tour/types/stringraw/), and that fixed the issue.
