### PR TITLE
chore: add format commit to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+650400e66c5a1e3784e81b2789798c8d78f2cfab  # start using shfmt


### PR DESCRIPTION
so [git-credit](https://github.com/pcrockett/rush-repo/blob/main/git-credit/git-credit) can cut through code formatting noise
